### PR TITLE
pg_dump/pg_restore respect clusters

### DIFF
--- a/lib/db.sh
+++ b/lib/db.sh
@@ -38,7 +38,11 @@ __lib::db::by_shortname() {
 }
 
 lib::db::psql::args::homebase() {
-  printf -- "-U ${HomebasePostgresUsername} -h ${HomebasePostgresHostname} $*"
+  local cluster_args
+  if hash pg_ctlcluster 2>/dev/null; then
+     cluster_args=" --cluster ${PGCLUSTER}"
+  fi
+  printf -- "-U ${HomebasePostgresUsername} -h ${HomebasePostgresHostname}${cluster_args} $*"
 }
 
 lib::db::psql-args() {


### PR DESCRIPTION
It always was challenging for me to use `bin/setup db`  b/c my ubuntu machine has installed multiple versions of postgres. I've added a workaround to respect PGCLUSTER variable. For some reason, pg_dump/pg_restore do not respect that variable in the first place.