### PR TITLE
Removed unused Node related variables

### DIFF
--- a/lib/settings.sh
+++ b/lib/settings.sh
@@ -3,9 +3,6 @@
 export True="1"
 export False="0"
 
-export HomebaseNodeVersion="9.11.2"
-export HomebaseNvmVersion="0.33.2"
-
 export HomebasePostgresVersion=${PostgreSQLVersion:-"9.4"}
 export HomebasePostgresHostname="localhost"
 export HomebasePostgresUsername="postgres"


### PR DESCRIPTION
Seems these variables are being used in [another repo](https://github.com/pioneerworks/Homebase1/blob/c4077654bfcc919ccde8f606cac061cf05016d54/bin/lib.bash#L26) and it makes no sense to have them here