### PR TITLE
PLAT-1708 GH security alert activesupport gem

### DIFF
--- a/lib/gem.sh
+++ b/lib/gem.sh
@@ -56,7 +56,7 @@ lib::gem::gemfile::version() {
   [[ -z ${gem} ]] && return
 
   if [[ -f Gemfile.lock ]]; then
-    egrep "^    ${gem} \([0-9]+\.[0-9]+\.[0-9]\)" Gemfile.lock | awk '{print $2}' | hbsed 's/[()]//g'
+    egrep "^    ${gem} \([0-9]+\.[0-9]+\.[0-9](.[0-9])?\)" Gemfile.lock | awk '{print $2}' | hbsed 's/[()]//g'
   fi
 }
 

--- a/test/Gemfile.lock.test
+++ b/test/Gemfile.lock.test
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.3)
+    activesupport (5.2.4.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -18,7 +18,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (= 5.2.3)
+  activesupport (= 5.2.4.3)
 
 RUBY VERSION
    ruby 2.5.5p157

--- a/test/gem_test.bats
+++ b/test/gem_test.bats
@@ -6,9 +6,9 @@ load test_helper
   export LibGem__GemListCache=/tmp/gem_list_test.txt
   rm -f ${LibGem__GemListCache}
   touch ${LibGem__GemListCache}
-  cp -f test/Gemfile.lock .
+  cp -f test/Gemfile.lock.test Gemfile.lock
   result=$(lib::gem::gemfile::version activesupport)
-  [[ "${result}" == "5.2.3" ]]
+  [[ "${result}" == "5.2.4.3" ]]
   [[ -d test && -f Gemfile.lock ]] && ( rm -f Gemfile.lock ; true ) 
 } 
 
@@ -16,8 +16,8 @@ load test_helper
   set -e
   export LibGem__GemListCache=/tmp/gem_list_test.txt
   gem_cache="${LibGem__GemListCache}"
-  echo "activesupport (5.1.0, 5.2.3, 4.2.7)" > ${gem_cache}
+  echo "activesupport (5.1.0, 5.2.4.3, 4.2.7)" > ${gem_cache}
   result=$(lib::gem::global::latest-version activesupport)
-  [[ "${result}" == "5.2.3" ]]
+  [[ "${result}" == "5.2.4.3" ]]
   [[ -f ${gem_cache} ]] && ( rm -f ${gem_cache}; true )
 }


### PR DESCRIPTION
https://joinhomebase.atlassian.net/browse/PLAT-1708

CVE-2020-8165
high severity
Vulnerable versions: >= 5.0.0, <= 5.2.4.2
Patched version: 5.2.4.3

—

Looks like it's a false positive alert b/c a finding is located in a test file.